### PR TITLE
add GitHub Actions workflow for build and publish docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Build and Publish Docker
+
+on:
+  push:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: rep2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY rootfs /
 
 WORKDIR /root
 
-RUN php -r "readfile('https://getcomposer.org/installer');" | php \
+RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --version 1.10.17\
  && ./composer.phar config -g repos.packagist composer https://packagist.jp \
  && ./composer.phar global require hirak/prestissimo
 


### PR DESCRIPTION
Raspberry Pi OS 64bitで動くDockerイメージが欲しかったのでamd64とarm64のイメージをビルドしてGitHub Container Registryにプッシュするworkflowを書きました。  
またComposer 2.0のリリースでビルドに失敗するようになっていたので1.10.17に固定しています。  
もしよければマージしてください。

workflowを動かすにはGitHubの右上メニューのFeature previewからImproved container supportをEnableにした上で、  
[Personal Access Tokens](https://github.com/settings/tokens)でwrite:packagesのトークンを発行してRepositoryのSettingsのSecretsに`CR_PAT`として設定する必要があります。  
またProfileページのPackagesタブからrep2を開きPackages SettingsでMake publicしない限り認証なしでのダウンロードはできるようになりません。

実際の例としては[Package rep2](https://github.com/users/ebith/packages/container/package/rep2)こういった感じになり、  
`docker run -d --name rep2 -p 10080:80 -v $PWD/rep2:/ext ghcr.io/ebith/rep2`でamd64/arm64どちらでもrep2が動くようになります。